### PR TITLE
Use bitmovin-staging aws keys

### DIFF
--- a/src/BitmovinThumbnailImageLambda/index.js
+++ b/src/BitmovinThumbnailImageLambda/index.js
@@ -28,7 +28,11 @@ const transferThumbToS3 = (res, message) => {
   const outputUrl = message.payload.outputUrl
   const bucket = process.env.STAGING_VIDEO_BUCKET
   const key = 'bitmovin/' + outputUrl.match(/[0-9]{2,}_[A-z 0-9]+$/)[0] + '/thumb.png';
-  const s3 = new AWS.S3();
+  const s3 = new AWS.S3({
+                  region: 'us-east-1',
+                  accessKeyId: process.env.AWS_KEY,
+                  secretAccessKey: process.env.AWS_SECRECY_KEY
+                        });
 
   let params = {
     Bucket: bucket,


### PR DESCRIPTION
After we create the thumbnail, we need to copy it from its location and write it to S3.  In order to do so, we need to use the aws keys for the bitmovin-staging user.  We will user the bitmovin-prod user for the production version of this lambda.

Tags: aws, s3, permissions